### PR TITLE
Update plain hashes to the right ones

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -167,9 +167,9 @@ All patches dropped, as they were merged upstream
 
 Plain sha256sum, unsigned EFI app:
 ```
-$ sha256sum shim*.efi
-9a73497f75b2a4c55cfd0648f3dbcbb5a16146a8920faa9bb7e4dea495c30d65  shimaa64.efi
-66367b2b6330e8be3654c6ba5e09278f2cf249fc77656f4d3f41f52dbb200fb9  shimx64.efi
+$ sha256sum 15.4-0ubuntu1/shim*.efi
+9a73497f75b2a4c55cfd0648f3dbcbb5a16146a8920faa9bb7e4dea495c30d65  15.4-0ubuntu1/shimaa64.efi
+14bb194ea823cad03da3d79cff93ce96d3aaa910955f19f1816b937e3c7db6eb  15.4-0ubuntu1/shimx64.efi
 ```
 
 Authenticode hashes:

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -22,7 +22,7 @@ Ubuntu
 ###### the appropriate gnu-efi source.
 ###### Please confirm this as the origin your shim.
 Build is based on shim-15.4.tar.gz2
-It is located at CanonicalLtd/shim-review@ubuntu-shim-amd64+arm64-20210407
+It is located at CanonicalLtd/shim-review@ubuntu-shim-amd64+arm64-20210408
 
 ###### What's the justification that this really does need to be signed for the whole world to be able to boot it:
 Ubuntu is a popular OS.


### PR DESCRIPTION
For some reasons authenticode hashes are the right ones,
but the plain sha256sum hashes were of some other build.

Correct them.